### PR TITLE
fix: set root terraform workspace directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "terraform"
-    directory: "/terraform"
+    directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
## What problem is this solving?
    Fix terraform root directory for Dependabot

## Types of changes

- [X] .github/dependabot.yml

## Additional Info

-  No

## Checklist

- [X] Bug fix (a non-breaking change that fixes an issue)
